### PR TITLE
Introduces a matrix build

### DIFF
--- a/.github/workflows/spm-build-test.yml
+++ b/.github/workflows/spm-build-test.yml
@@ -8,14 +8,23 @@ on:
 
 jobs:
   build:
-
-    runs-on: macos-11
-
+    strategy:
+      matrix:
+        destination:
+          - 'platform=iOS Simulator,OS=13.1,name=iPhone 8'
+          - 'platform=macOS,arch=arm64'
+          - 'platform=macOS,arch=x86_64'
+        xcode: ['13.1']
+        os: ['macos-11']
+    runs-on: ${{ matrix.os }}
     steps:
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ matrix.xcode }}
     - uses: actions/checkout@v2
     - name: Checkout LFS objects
       run: git lfs checkout
     - name: Build
-      run: swift build -v
+      run: xcodebuild build -scheme Carpaccio-Package -destination ${{matrix.destination}}
     - name: Run tests
-      run: swift test -v
+      run: xcodebuild test -scheme Carpaccio-Package -destination ${{matrix.destination}}

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,14 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Carpaccio",
-    platforms: [.macOS(.v10_15),
-                .iOS(.v14)],
+    platforms: [
+        .macOS(.v11),
+        .iOS(.v14)
+    ],
     products: [
         .library(
             name: "Carpaccio",

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Carpaccio",
     platforms: [
-        .macOS(.v11),
+        .macOS(.v10_15),
         .iOS(.v14)
     ],
     products: [

--- a/Sources/Carpaccio/CIImage+Extensions.swift
+++ b/Sources/Carpaccio/CIImage+Extensions.swift
@@ -59,8 +59,16 @@ public extension CIImage {
         rawFilter.setValue(options.boostShadowAmount, forKey: CIRAWFilterOption.boostShadowAmount.rawValue)
         rawFilter.setValue(options.enableVendorLensCorrection, forKey: CIRAWFilterOption.enableVendorLensCorrection.rawValue)
 
-        // Preserve pixel values beyond 0.0 … 1.0, which wide colour images will have
-        rawFilter.setValue(true, forKey: CIRAWFilterOption.ciInputEnableEDRModeKey.rawValue)
+        // Preserve pixel values beyond 0.0 … 1.0
+        if #available(macOS 12, *), #available(iOS 15, *) {
+            rawFilter.setValue(true, forKey: CIRAWFilterOption.ciInputEnableEDRModeKey.rawValue)
+        } else {
+            // For the life of me, I could not figure out, in a reasonable time, how to use the legacy SDK constant named
+            // kCIInputEnableEDRModeKey here, and get past Xcdode 13.1's compiler error saying that it has been renamed to
+            // CIRAWFilterOption.ciInputEnableEDRModeKey. Life's too short, so we will use a direct literal value, as extracted
+            // from the console.
+            rawFilter.setValue(true, forKey: "inputEnableEDRMode")
+        }
 
         guard let rawImage = rawFilter.outputImage else {
             throw ImageLoadingError.failedToDecode(URL: url, message: "Failed to decode image at \(url.path)")


### PR DESCRIPTION
Introduces a matrix build and specifies the Xcode version, and build destination, accurately.

There is also some commented out boilerplate added in this PR to support testing the iOS target, but that's left out for now until https://github.com/mz2/Carpaccio/issues/19 is resolved.